### PR TITLE
Add Monitor IDs Output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,6 @@
+output "monitors_id" {
+  value = tolist([
+    for monitor in uptimerobot_monitor.monitor :
+    monitor.id
+  ])
+}


### PR DESCRIPTION
For easy access to just-created monitors, add an output that has a list of all the monitors created by the module