### PR TITLE
add uptime robot monitor authentication variables and tf created alert contact

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,13 +34,16 @@ resource "uptimerobot_monitor" "monitor" {
   http_auth_type = lookup(each.value, "http_auth_type", null)
 
   dynamic "alert_contact" {
-    for_each = flatten([
-      [each.value.alert_contacts == null ? [] : each.value.alert_contacts],
-      [each.value.alert_contact_ids == null ? [] : each.value.alert_contact_ids],
-    ])
-
+    for_each = each.value.alert_contacts == null ? [] : each.value.alert_contacts
     content {
-      id = try(data.uptimerobot_alert_contact.alert_contact[alert_contact.key].id, alert_contact.value)
+      id = data.uptimerobot_alert_contact.alert_contact[alert_contact.key].id
+    }
+  }
+
+  dynamic "alert_contact" {
+    for_each = each.value.alert_contact_ids == null ? [] : each.value.alert_contact_ids
+    content {
+      id = alert_contact.value
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,9 +9,7 @@ terraform {
 
 locals {
   monitors = flatten(
-    [for monitor in var.uptimerobot_monitors :
-      monitor.alert_contacts == null ? [] : monitor.alert_contacts
-    ]
+    [for monitor in var.uptimerobot_monitors : coalesce(monitor.alert_contacts, [])]
   )
 }
 
@@ -34,16 +32,20 @@ resource "uptimerobot_monitor" "monitor" {
   http_auth_type = lookup(each.value, "http_auth_type", null)
 
   dynamic "alert_contact" {
-    for_each = each.value.alert_contacts == null ? [] : each.value.alert_contacts
+    for_each = coalesce(each.value.alert_contacts, [])
+    iterator = contact
+
     content {
-      id = data.uptimerobot_alert_contact.alert_contact[alert_contact.key].id
+      id = data.uptimerobot_alert_contact.alert_contact[contact.key].id
     }
   }
 
   dynamic "alert_contact" {
-    for_each = each.value.alert_contact_ids == null ? [] : each.value.alert_contact_ids
+    for_each = coalesce(each.value.alert_contact_ids, [])
+    iterator = contact
+
     content {
-      id = alert_contact.value
+      id = contact.value
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,17 @@
 variable "uptimerobot_monitors" {
   description = "List of monitors to set up with their respective information"
   type = map(object({
-    alert_contacts = list(string)
-    friendly_name  = string
-    monitor_type   = string
-    keyword_type   = string
-    keyword_value  = string
-    url            = string
-    interval       = number
-    http_username  = optional(string)
-    http_password  = optional(string)
-    http_auth_type = optional(string)
+    alert_contacts    = optional(list(string))
+    friendly_name     = string
+    monitor_type      = string
+    keyword_type      = string
+    keyword_value     = string
+    url               = string
+    interval          = number
+    http_username     = optional(string)
+    http_password     = optional(string)
+    http_auth_type    = optional(string)
+    alert_contact_ids = optional(list(number))
   }))
 }
 variable "uptimerobot_status_page_monitors" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,9 @@ variable "uptimerobot_monitors" {
     keyword_value  = string
     url            = string
     interval       = number
+    http_username  = optional(string)
+    http_password  = optional(string)
+    http_auth_type = optional(string)
   }))
 }
 variable "uptimerobot_status_page_monitors" {


### PR DESCRIPTION
- Part of https://github.com/onaio/infrastructure/pull/6758 and https://github.com/onaio/canopy/issues/2882
- add optional uptime robot monitor authentication variables
- allow adding a terraform created alert contact